### PR TITLE
feat(config): use the host parameter and not a custom variable.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,6 @@
       <supportlevel value="unsupported" />
     </information>
     <configuration>
-      <property key="hostName" label="hostName" type="string" description="HostName" default="localhost" multiline="false" />
       <property key="dbName" label="dbName" type="string" description="Database Name" default="" multiline="false" />
       <property key="dbPort" label="dbPort" type="string" description="Database Port" default="5432" multiline="false" />
       <property key="dbUsername" label="dbUsername" type="string" description="Database Username" default="isagabi" multiline="false" />
@@ -114,4 +113,3 @@
     </metricgroup>
   </extension>
 </plugin>
-

--- a/src/br/com/elosoft/postmon/PostPlugin.java
+++ b/src/br/com/elosoft/postmon/PostPlugin.java
@@ -19,7 +19,7 @@ public class PostPlugin {
 	public Status setup(MonitorEnvironment env) throws Exception {
 
 		br.com.elosoft.postmon.jdbc.Connection c = new br.com.elosoft.postmon.jdbc.Connection();
-		conn = c.getConnection(env.getConfigString("hostName"),
+		conn = c.getConnection(env.getHost().getAddress(),
 				env.getConfigString("dbPort"), env.getConfigString("dbName"),
 				env.getConfigString("dbUsername"),
 				env.getConfigPassword("dbPassword"));


### PR DESCRIPTION
Hello Fernando,

I actually tried your plugin and find it very useful. 

We are actually working on a few hosts. We are using labels or group hosts. In your code, you used a custom variable. I think it's best to use :
env.getHost().getAddress()
Here the java doc description :

> getHost
> PluginEnvironment.Host getHost()
> Returns the host configured for the Plugin. If multiple hosts are configured the Plugins execute method will be called repeatedly for each host. If the Plugin does not support hosts, this method will return null.
> Returns:the configured host, or null if hosts are not supported

I made some quick test on my side and everything seems to be working well.

Please fill free to ask any change if anything seems buggy.

Thank you for your time.

Regards,

Sylvain Lebon
